### PR TITLE
added Core Hours field and query logging

### DIFF
--- a/templates/account.html
+++ b/templates/account.html
@@ -63,17 +63,18 @@
                 </h5>
                 <table id="table" class="table table-striped table-bordered">
                     <head>
-                    <tr> <th>user</th> <th>cores</th> <th>memory</th> <th>time limit</th> <th>total efficiency</th> <th>jobs</th></tr>
+                    <tr> <th>user</th> <th>cores</th> <th>memory</th> <th>time
+                    limit</th> <th>total efficiency</th> <th>core hours</th></tr>
                     </thead>
                     <tbody>
                     {% for i in users|sort() %}
                     <tr> 
                         <th><a href={{url_for('viewUser', user_name=i)}}>{{i}}</a></th> 
-                        <td>{{users[i]['cores']|round(2) if users[i]['cores'] != '-' else '<div title="This user used the minimum value for this resource. A score was not calculated." style="color: green;">0</div>'|safe}}</td> 
+                        <td>{{users[i]['cores']|round(2) if users[i]['cores'] != '-' else '<div title="This user used the minimum value for this resource. A score was not calculated." style="color: green;">0</div>'|safe}}</td>
                         <td>{{users[i]['memory']|round(2) if users[i]['memory'] != '-' else '<div title="This user used the minimum value for this resource. A score was not calculated." style="color: green;">0</div>'|safe}}</td> 
                         <td>{{users[i]['tlimit']|round(2) if users[i]['tlimit'] != '-' else '<div title="This user used the minimum value for this resource. A score was not calculated." style="color: green;">0</div>'|safe}}</td> 
                         <td>{{users[i]['total']|round(2) if users[i]['total'] != '-' else '<div title="This user used the minimum value for this resource. A score was not calculated." style="color: green;">0</div>'|safe}}</td> 
-                        <td>{{users[i]['jobsum']|round(2) if users[i]['jobsum'] != '-' else 0 |safe}}</td> 
+                        <td>{{users[i]['core hours']}}</td> 
                     </tr>
                     {%endfor%}
                     </tbody>

--- a/templates/cluster.html
+++ b/templates/cluster.html
@@ -51,24 +51,12 @@
 </div>
 </div>
 
-<div class="col">
+    <div class="col">
 <div class="card text-center">
     <div class="card-body">
         <b>{{total_score['tlimit-score']}}% Time Efficiency</b>
         <div class="small">
             {{(total_usage['timeuse'] / (60*60))|int}} Hours
-        </div>
-    </div>
-</div>
-</div>
-
-
-    <div class="col">
-<div class="card text-center">
-    <div class="card-body">
-        <b>{{total_usage['jobsum']}} Jobs</b>
-        <div class="small">
-            {{((total_usage['jobsum'] / active_users)|int) if total_usage['jobsum'] else 0}} per User
         </div>
     </div>
 </div>

--- a/templates/home.html
+++ b/templates/home.html
@@ -32,7 +32,8 @@
                 </h5>
                 <table id="table" class="table table-striped table-bordered">
                     <thead>
-                    <tr> <th>rank</th> <th>account</th> <th>cores</th> <th>memory</th> <th>time limit</th> <th>jobs</th> <th>total efficiency</th> </tr>
+                    <tr> <th>rank</th> <th>account</th> <th>cores</th> <th>memory</th> <th>time
+                    limit</th><th>total efficiency</th>  <th>core hours</th> </tr>
                     </thead>
                     <tbody>
                     {% for i in account_ranks %}
@@ -46,8 +47,8 @@
                         <td>{{i[2]|round(2) if i[2] != '-' else '<div title="This user used the minimum value for this resource. A score was not calculated." style="color: green;">0</div>'|safe}}</td> 
                         <td>{{i[3]|round(2) if i[3] != '-' else '<div title="This user used the minimum value for this resource. A score was not calculated." style="color: green;">0</div>'|safe}}</td> 
                         <td>{{i[4]|round(2) if i[4] != '-' else '<div title="This user used the minimum value for this resource. A score was not calculated." style="color: green;">0</div>'|safe}}</td>
-                        <td>{{i[6] if i[6] != '-' else '<div title="This user used the minimum value for this resource. A score was not calculated.">0</div>'|safe}}</td>
-                        <th scope="row">{{i[5]|round(2) if i[5] != '-' else i[5]}}</th> 
+                        <td>{{i[5]|round(2) if i[5] != '-' else i[5]}}</td>
+			<td>{{i[7]}}</td>
                     </tr>
                     {% endfor %}
                     </tbody>

--- a/templates/user.html
+++ b/templates/user.html
@@ -54,11 +54,20 @@
                 
                 <table class="table table-striped table-bordered">
                     <thead> 
-                    <tr> <th>account</th> <th>cores</th> <th>memory</th>  <th>time limit</th>  <th>total efficiency</th></tr>
+                    <tr> <th>account</th> <th>cores</th> <th>memory</th>  <th>time
+                    limit</th>  <th>total efficiency</th><th>core hours</th></tr>
                     </thead>
                     <tbody>
                      {% for acc in accounts %}
-                     <tr><th><a href={{url_for('viewAccount', account_name=acc)}}>{{acc}}</a></th> <td>{{accounts[acc]['cores']}}</td> <td>{{accounts[acc]['memory']}}</td> <td>{{accounts[acc]['tlimit']}}</td> <td>{{accounts[acc]['total']}}</td></tr>    
+                     <tr>
+		       <th><a href={{url_for('viewAccount',
+			      account_name=acc)}}>{{acc}}</a>
+		       </th>
+		       <td>{{accounts[acc]['cores']}}</td>
+		       <td>{{accounts[acc]['memory']}}</td>
+		       <td>{{accounts[acc]['tlimit']}}</td>
+		       <td>{{accounts[acc]['total']}}</td>
+		       <td>{{accounts[acc]['core hours']}}</td></tr>    
                      {% endfor %}
                     </tbody>
                 </table>


### PR DESCRIPTION
The user_efficiency script displays "Core Hours" so it's being added to doppler for consistency.

Here's a screenshot with doppler running on a VM:
![image](https://user-images.githubusercontent.com/51888667/81022004-6226db00-8e21-11ea-9879-42424a6e4680.png)

The logging is important as doppler has been crashing a lot lately. This appears to be from timeouts because of slow queries. Maybe it'll turn out to be a specific query but either way this will help us track down which jobid, query, and at what time.

Here's a snippet of the log. These logs will be written to doppler.log on alula.
```
[2020-05-01 15:40:49 -0700] [10853] [CUSTOM] Finished query "SELECT date, SUM(idealcpu), SUM(cputime), SUM(memoryreq), SUM(tlimitreq), SUM(tlimituse), SUM(memoryuse), SUM(jobsum) FROM jobs WHERE username = 'coc25' AND date >= '2020-04-24' GROUP BY date ORDER BY date", received 7 rows
[2020-05-01 15:40:49 -0700] [10853] [CUSTOM] Executing query "SELECT date, SUM(idealcpu), SUM(cputime), SUM(memoryreq), SUM(tlimitreq), SUM(tlimituse), SUM(memoryuse), SUM(jobsum) FROM jobs WHERE username = %s AND date >= %s GROUP BY date ORDER BY date" with args ['jtl276', datetime.date(2020, 4, 24)]
[2020-05-01 15:40:49 -0700] [10853] [CUSTOM] Finished query "SELECT date, SUM(idealcpu), SUM(cputime), SUM(memoryreq), SUM(tlimitreq), SUM(tlimituse), SUM(memoryuse), SUM(jobsum) FROM jobs WHERE username = 'jtl276' AND date >= '2020-04-24' GROUP BY date ORDER BY date", received 3 rows
[2020-05-01 15:40:49 -0700] [10853] [CUSTOM] Executing query "SELECT date, SUM(idealcpu), SUM(cputime), SUM(memoryreq), SUM(tlimitreq), SUM(tlimituse), SUM(memoryuse), SUM(jobsum) FROM jobs WHERE username = %s AND date >= %s GROUP BY date ORDER BY date" with args ['lb968', datetime.date(2020, 4, 24)]
[2020-05-01 15:40:49 -0700] [10853] [CUSTOM] Finished query "SELECT date, SUM(idealcpu), SUM(cputime), SUM(memoryreq), SUM(tlimitreq), SUM(tlimituse), SUM(memoryuse), SUM(jobsum) FROM jobs WHERE username = 'lb968' AND date >= '2020-04-24' GROUP BY date ORDER BY date", received 5 rows
[2020-05-01 15:40:49 -0700] [10853] [CUSTOM] Executing query "SELECT date, SUM(idealcpu), SUM(cputime), SUM(memoryreq), SUM(tlimitreq), SUM(tlimituse), SUM(memoryuse), SUM(jobsum) FROM jobs WHERE username = %s AND date >= %s GROUP BY date ORDER BY date" with args ['rlm284', datetime.date(2020, 4, 24)]
[2020-05-01 15:40:49 -0700] [10853] [CUSTOM] Finished query "SELECT date, SUM(idealcpu), SUM(cputime), SUM(memoryreq), SUM(tlimitreq), SUM(tlimituse), SUM(memoryuse), SUM(jobsum) FROM jobs WHERE username = 'rlm284' AND date >= '2020-04-24' GROUP BY date ORDER BY date", received 2 rows

[2020-05-01 15:40:49 -0700] [10854] [CUSTOM] Finished query "SELECT date, SUM(idealcpu), SUM(cputime), SUM(memoryreq), SUM(tlimitreq), SUM(tlimituse), SUM(memoryuse), SUM(jobsum) FROM jobs WHERE account = 'trujillo' AND date >= '2020-04-24' GROUP BY date ORDER BY date", received 7 rows
```