### PR TITLE
Added "gpu hrs" and "gpu eff"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ Jinja2>=2.10.1
 MarkupSafe==1.0
 mysql-connector==2.1.6
 pygal==2.4.0
-Werkzeug==0.14.1
+Werkzeug==1.0.1

--- a/templates/account.html
+++ b/templates/account.html
@@ -36,8 +36,20 @@
                     {% endif %}
                 </h3>
                 <table class="table table-hover table-striped">
-                     <tr> <th>cores</th> <th>memory</th>  <th>time limit</th>  <th>total efficiency</th></tr>
-                     <tr> <td>{{total['cores']}}</td> <td>{{total['memory']}}</td> <td>{{total['tlimit']}}</td> <td>{{total['total']}}</td></tr>    
+                  <tr>
+		    <th>cpu eff</th>
+		    <th>mem eff</th>
+		    <th>time eff</th>
+		    <th>gpu eff</th>
+		    <th>total eff</th>
+		  </tr>
+                  <tr>
+		    <td>{{total['cores']}}</td>
+		    <td>{{total['memory']}}</td>
+		    <td>{{total['tlimit']}}</td>
+		    <td>{{total['gpu']}}</td>
+		    <td>{{total['total']}}</td>
+		  </tr>    
                 </table>
             </div>
         </div>
@@ -63,8 +75,15 @@
                 </h5>
                 <table id="table" class="table table-striped table-bordered">
                     <head>
-                    <tr> <th>user</th> <th>cores</th> <th>memory</th> <th>time
-                    limit</th> <th>total efficiency</th> <th>core hours</th></tr>
+                      <tr>
+			<th>user</th>
+			<th>cpu eff</th>
+			<th>mem eff</th>
+			<th>time ff</th>
+			<th>total eff</th>
+			<th>cpu hrs</th>
+			<th>gpu hrs</th>
+		      </tr>
                     </thead>
                     <tbody>
                     {% for i in users|sort() %}
@@ -73,8 +92,9 @@
                         <td>{{users[i]['cores']|round(2) if users[i]['cores'] != '-' else '<div title="This user used the minimum value for this resource. A score was not calculated." style="color: green;">0</div>'|safe}}</td>
                         <td>{{users[i]['memory']|round(2) if users[i]['memory'] != '-' else '<div title="This user used the minimum value for this resource. A score was not calculated." style="color: green;">0</div>'|safe}}</td> 
                         <td>{{users[i]['tlimit']|round(2) if users[i]['tlimit'] != '-' else '<div title="This user used the minimum value for this resource. A score was not calculated." style="color: green;">0</div>'|safe}}</td> 
-                        <td>{{users[i]['total']|round(2) if users[i]['total'] != '-' else '<div title="This user used the minimum value for this resource. A score was not calculated." style="color: green;">0</div>'|safe}}</td> 
-                        <td>{{users[i]['core hours']}}</td> 
+                        <td>{{users[i]['total']|round(2) if users[i]['total'] != '-' else '<div title="This user used the minimum value for this resource. A score was not calculated." style="color: green;">0</div>'|safe}}</td>
+                        <td>{{users[i]['core hours']}}</td>
+			<td>{{users[i]['gpu hours']}}</td>
                     </tr>
                     {%endfor%}
                     </tbody>

--- a/templates/cluster.html
+++ b/templates/cluster.html
@@ -5,63 +5,66 @@
 
 <!-- cluster stats -->
 <div class="row">
-
-    <div class="col">
-
-<div class="card text-center">
-            <div class="card-body">
-                <b>{{active_users}} Active Users</b>
-                <div class="small">
-                    {{total_users}} Total Users
-                </div>
-            </div>
+  <div class="col">
+    <div class="card text-center">
+      <div class="card-body">
+        <b>{{active_users}} Active Users</b>
+        <div class="small">
+          {{total_users}} Total Users
         </div>
+      </div>
     </div>
-
-    <div class="col">
-<div class="card text-center">
-    <div class="card-body">
+  </div>
+  <div class="col">
+    <div class="card text-center">
+      <div class="card-body">
         <b>{{active_accounts}} Active Accounts</b>
         <div class="small">
-            {{total_accounts}} Total Accounts
+          {{total_accounts}} Total Accounts
         </div>
+      </div>
     </div>
-</div>
-</div>
-
-    <div class="col">
-<div class="card text-center">
-    <div class="card-body">
+  </div>
+  <div class="col">
+    <div class="card text-center">
+      <div class="card-body">
         <b>{{total_score['cpu-score']}}% Core Efficiency</b>
         <div class="small">
-            {{((total_usage['cputime'] / (60*60))|int) if total_usage['cputime'] else 0}} Core Hours
+          {{((total_usage['cputime'] / (60*60))|int) if total_usage['cputime'] else 0}} Core Hours
         </div>
+      </div>
     </div>
-</div>
-</div>
-
-    <div class="col">
-<div class="card text-center">
-    <div class="card-body">
+  </div>
+  <div class="col">
+    <div class="card text-center">
+      <div class="card-body">
         <b>{{total_score['mem-score']}}% Memory Efficiency</b>
         <div class="small">
-            {{(total_usage['memuse'] / 1024)|int}} GB
+          {{(total_usage['memuse'] / 1024)|int}} GB
         </div>
+      </div>
     </div>
-</div>
-</div>
-
+  </div>
     <div class="col">
-<div class="card text-center">
-    <div class="card-body">
-        <b>{{total_score['tlimit-score']}}% Time Efficiency</b>
-        <div class="small">
+      <div class="card text-center">
+	<div class="card-body">
+          <b>{{total_score['tlimit-score']}}% Time Efficiency</b>
+          <div class="small">
             {{(total_usage['timeuse'] / (60*60))|int}} Hours
-        </div>
+          </div>
+	</div>
+      </div>
     </div>
-</div>
-</div>
-
+    <div class="col">
+      <div class="card text-center">
+	<div class="card-body">
+          <b>GPU Usage</b>
+          <div class="small">
+	    {{(total_usage['gpuhours'] | int)}} Hours
+          </div>
+	</div>
+      </div>
+    </div>
 </div>
 
 <!-- graphs -->

--- a/templates/home.html
+++ b/templates/home.html
@@ -60,8 +60,8 @@
                         <td>{{i['time limit']|round(2) if i['time limit'] != '-' else '<div title="This user used the minimum value for this resource. A score was not calculated." style="color: green;">0</div>'|safe}}</td>
 			<td>{{i['gpu']|round(2) if i['gpu'] != '-' else '<div title="This user used the minimum value for this resource. A score was not calculated." style="color: green;">0</div>'|safe}}</td>
 			<td>{{i['total efficiency']|round(2) if i['total efficiency'] != '-' else i['total efficiency']}}</td>
-                        <td>{{i['core hours']}}</td>
-                        <td>{{i['gpu hours']}}</td>
+                        <td>{{i['core hours']|float|round(2) if i['core hours'] != '-' else i['core hours']}}</td>
+                        <td>{{i['gpu hours']|float|round(2) if i['gpu hours'] != '-' else i['gpu hours']}}</td>
                     </tr>
                     {% endfor %}
                     </tbody>

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,11 +1,11 @@
 {% extends 'base.html' %}
 
 {% block content %}
+
 <title> Monsoon Jobstats </title>
 
-
 <!-- account ranks  -->
-<div class="row">    
+<div class="row">
     <div class="col-md-12">
         <div class="card">
             <div class="card-body">
@@ -30,25 +30,38 @@
                         {% endif %}
                     {% endif %}
                 </h5>
+                <div>
+                </div>
                 <table id="table" class="table table-striped table-bordered">
-                    <thead>
-                    <tr> <th>rank</th> <th>account</th> <th>cores</th> <th>memory</th> <th>time
-                    limit</th><th>total efficiency</th>  <th>core hours</th> </tr>
-                    </thead>
+                  <thead>
+                    <tr>
+                      <th>rank</th>
+                      <th>acct</th>
+                      <th>cpu eff</th>
+                      <th>mem eff</th>
+                      <th>time eff</th>
+                      <th>gpu eff</th>
+                      <th>total eff</th>                      
+                      <th>cpu hrs</th>
+                      <th>gpu hrs</th>
+                    </tr>
+                  </thead>
                     <tbody>
                     {% for i in account_ranks %}
                     <tr>
-                        <th scope="row">{{i[0]}}</th>
+                        <th scope="row">{{i['rank']}}</th>
                         {% if view == 'users' %} 
-                        <td><a href={{url_for('viewUser', user_name=i[1], time=time, view=view)}}>{{i[1]}}</a></td> 
+                        <td><a href={{url_for('viewUser', user_name=i['name'], time=time, view=view)}}>{{i['name']}}</a></td> 
                         {% else %}
-                        <td><a href={{url_for('viewAccount', account_name=i[1], time=time, view=view)}}>{{i[1]}}</a></td> 
+                        <td><a href={{url_for('viewAccount', account_name=i['name'], time=time, view=view)}}>{{i['name']}}</a></td> 
                         {% endif %}
-                        <td>{{i[2]|round(2) if i[2] != '-' else '<div title="This user used the minimum value for this resource. A score was not calculated." style="color: green;">0</div>'|safe}}</td> 
-                        <td>{{i[3]|round(2) if i[3] != '-' else '<div title="This user used the minimum value for this resource. A score was not calculated." style="color: green;">0</div>'|safe}}</td> 
-                        <td>{{i[4]|round(2) if i[4] != '-' else '<div title="This user used the minimum value for this resource. A score was not calculated." style="color: green;">0</div>'|safe}}</td>
-                        <td>{{i[5]|round(2) if i[5] != '-' else i[5]}}</td>
-			<td>{{i[6]}}</td>
+                        <td>{{i['cores']|round(2) if i['cores'] != '-' else '<div title="This user used the minimum value for this resource. A score was not calculated." style="color: green;">0</div>'|safe}}</td> 
+                        <td>{{i['memory']|round(2) if i['memory'] != '-' else '<div title="This user used the minimum value for this resource. A score was not calculated." style="color: green;">0</div>'|safe}}</td>
+                        <td>{{i['time limit']|round(2) if i['time limit'] != '-' else '<div title="This user used the minimum value for this resource. A score was not calculated." style="color: green;">0</div>'|safe}}</td>
+			<td>{{i['gpu']|round(2) if i['gpu'] != '-' else '<div title="This user used the minimum value for this resource. A score was not calculated." style="color: green;">0</div>'|safe}}</td>
+			<td>{{i['total efficiency']|round(2) if i['total efficiency'] != '-' else i['total efficiency']}}</td>
+                        <td>{{i['core hours']}}</td>
+                        <td>{{i['gpu hours']}}</td>
                     </tr>
                     {% endfor %}
                     </tbody>

--- a/templates/user.html
+++ b/templates/user.html
@@ -54,8 +54,16 @@
                 
                 <table class="table table-striped table-bordered">
                     <thead> 
-                    <tr> <th>account</th> <th>cores</th> <th>memory</th>  <th>time
-                    limit</th>  <th>total efficiency</th><th>core hours</th></tr>
+                      <tr>
+			<th>acct</th>
+			<th>cpu eff</th>
+			<th>mem eff</th>
+			<th>time eff</th>
+			<th>gpu eff</th>
+			<th>total eff</th>
+			<th>cpu hrs</th>
+			<th>gpu hrs</th>
+		    </tr>
                     </thead>
                     <tbody>
                      {% for acc in accounts %}
@@ -66,8 +74,11 @@
 		       <td>{{accounts[acc]['cores']}}</td>
 		       <td>{{accounts[acc]['memory']}}</td>
 		       <td>{{accounts[acc]['tlimit']}}</td>
+		       <td>{{accounts[acc]['gpu']}}</td>
 		       <td>{{accounts[acc]['total']}}</td>
-		       <td>{{accounts[acc]['core hours']}}</td></tr>    
+		       <td>{{accounts[acc]['core hours']}}</td>
+		       <td>{{accounts[acc]['gpu hours']}}</td>
+		     </tr>    
                      {% endfor %}
                     </tbody>
                 </table>


### PR DESCRIPTION
Mainly "gpu eff" and "gpu hrs" were added to all pages. This includes the cluster stats graph on the main page, the user/account tables, and the user/account views. I tested it using a CSV file with some handpicked values:
```
username,account,date,jobid,ngpu,gputime,idealgpu
jfg95,vigil-hayes,2020-06-22,100001,1,396,1000
jfg95,vigil-hayes,2020-06-22,100002,2,396,1100
jfg95,vigil-hayes,2020-06-28,100003,2,396,400
jfg95,vigil-hayes,2020-06-28,100004,4,396,900
cbc,coffey,2020-06-24,100005,1,396,1000
cbc,coffey,2020-06-24,100006,1,400,1000
cbc,coffey,2020-06-24,100007,1,500,1000
cbc,coffey,2020-06-24,100008,20,800,1000
```
![image](https://user-images.githubusercontent.com/51888667/88900509-4e162e00-d204-11ea-9403-85a9d173376b.png)
![image](https://user-images.githubusercontent.com/51888667/88900653-8ddd1580-d204-11ea-9785-e2c2d7e9c8c0.png)


