### PR TITLE
Made gpu summary column on home page consistent with cpu

### DIFF
--- a/app.py
+++ b/app.py
@@ -397,7 +397,7 @@ def renderGraph(graph_function, data_set):
         data = getScore(since=date.today()-timedelta(days), by_date=True)
 
         data_points = {
-            'cores': [],
+            'cpu': [],
             'memory': [],
             'time limit': [],
             'total efficiency': [],
@@ -409,13 +409,13 @@ def renderGraph(graph_function, data_set):
             if current in data:
                 score = data[current]
                
-                data_points['cores'].append(score['cpu-score'])
+                data_points['cpu'].append(score['cpu-score'])
                 data_points['memory'].append(score['mem-score'])
                 data_points['time limit'].append(score['tlimit-score'])
                 data_points['gpu'].append(score['gpu-score'])
                 data_points['total efficiency'].append(score['total'])
             else:
-                data_points['cores'].append(None)
+                data_points['cpu'].append(None)
                 data_points['memory'].append(None)
                 data_points['time limit'].append(None)
                 data_points['gpu'].append(None)
@@ -592,7 +592,7 @@ def renderAccountLineGraph(account_name):
     line_graph.x_labels = [date.today() - timedelta(i) for i in range(days, 1, -1)]
 
     data_points = {
-        'cores': [],
+        'cpu': [],
         'memory': [],
         'time limit': [],
         'total efficiency': [],
@@ -604,13 +604,13 @@ def renderAccountLineGraph(account_name):
         if current in data:
             score = normalize(data[current], all_scores=True)
 
-            data_points['cores'].append(score['cpu-score'])
+            data_points['cpu'].append(score['cpu-score'])
             data_points['memory'].append(score['mem-score'])
             data_points['time limit'].append(score['tlimit-score'])
             data_points['gpu'].append(score['gpu-score'])
             data_points['total efficiency'].append(score['total'])
         else:
-            data_points['cores'].append(None)
+            data_points['cpu'].append(None)
             data_points['memory'].append(None)
             data_points['time limit'].append(None)
             data_points['gpu'].append(None)
@@ -641,7 +641,7 @@ def renderAccountUsersGraph(account_name):
 
     # Render the pie graph
     pie_graph = pygal.Pie()
-    pie_graph.title = 'Core Hours Per User'
+    pie_graph.title = 'CPU Hours Per User'
     for i in sorted(data.keys()):
         pie_graph.add(i, [{
             "value": data[i],
@@ -771,7 +771,7 @@ def renderUserAccountLineGraph(user_name, account=None):
     line_graph.x_labels = [date.today() - timedelta(i) for i in range(days)]
 
     data_points = {
-        'cores': [],
+        'cpu': [],
         'memory': [],
         'time limit': [],
         'total efficiency': [],
@@ -783,13 +783,13 @@ def renderUserAccountLineGraph(user_name, account=None):
         if current in data:
             score = normalize(data[current], all_scores=True)
             
-            data_points['cores'].append(score['cpu-score'])
+            data_points['cpu'].append(score['cpu-score'])
             data_points['memory'].append(score['mem-score'])
             data_points['time limit'].append(score['tlimit-score'])
             data_points['gpu'].append(score['gpu-score'])
             data_points['total efficiency'].append(score['total'])
         else:
-            data_points['cores'].append(None)
+            data_points['cpu'].append(None)
             data_points['memory'].append(None)
             data_points['gpu'].append(None)
             data_points['time limit'].append(None)

--- a/jobstats.py
+++ b/jobstats.py
@@ -103,10 +103,10 @@ class Jobstats:
             try:
                 # IMPORTANT: gputime and idealgpu are in seconds
                 #            similar to cputime and idealcpu
-                gpu_dict[key][0] += gputime / 3600.0
-                gpu_dict[key][1] += idealgpu / 3600.0
+                gpu_dict[key][0] += gputime
+                gpu_dict[key][1] += idealgpu
             except:
-                gpu_dict[key] = [gputime / 3600.0, idealgpu / 3600.0]
+                gpu_dict[key] = [gputime, idealgpu]
 
         for key in gpu_dict:
             username, account, date = key.split(":")
@@ -114,8 +114,8 @@ class Jobstats:
                 if result[i]['username'] == username and \
                    result[i]['account'] == account and \
                    result[i]['date'].strftime('%Y-%m-%d') == date:
-                    result[i]['gpuhours'] = gpu_dict[key][0]
-                    result[i]['gpureq'] = gpu_dict[key][1]
+                    result[i]['gpuhours'] = gpu_dict[key][0] / 3600.0
+                    result[i]['gpureq'] = gpu_dict[key][1] / 3600.0
 
 
         for i in range(len(result)):

--- a/templates/cluster.html
+++ b/templates/cluster.html
@@ -28,9 +28,9 @@
   <div class="col">
     <div class="card text-center">
       <div class="card-body">
-        <b>{{total_score['cpu-score']}}% Core Efficiency</b>
+        <b>{{total_score['cpu-score']}}% CPU Efficiency</b>
         <div class="small">
-          {{((total_usage['cputime'] / (60*60))|int) if total_usage['cputime'] else 0}} Core Hours
+          {{((total_usage['cputime'] / (60*60))|int) if total_usage['cputime'] else 0}} CPU Hours
         </div>
       </div>
     </div>
@@ -55,16 +55,16 @@
 	</div>
       </div>
     </div>
-    <div class="col">
-      <div class="card text-center">
-	<div class="card-body">
-          <b>GPU Usage</b>
-          <div class="small">
-	    {{(total_usage['gpuhours'] | int)}} Hours
-          </div>
-	</div>
+  <div class="col">
+    <div class="card text-center">
+      <div class="card-body">
+        <b>{{total_score['gpu-score']}}% GPU Efficiency</b>
+        <div class="small">
+          {{((total_usage['gpuhours'] | int) if total_usage['cputime'] else 0)}} GPU Hours
+        </div>
       </div>
     </div>
+  </div>
 </div>
 
 <!-- graphs -->


### PR DESCRIPTION
The summary column is shown just below the nav bar of the home page.
![image](https://user-images.githubusercontent.com/51888667/89082055-c8000180-d341-11ea-9a1a-bd60da846733.png)

Also changed some lingering core labels to cpu in graphs.