### PR TITLE
None% to 0% hotfix

### DIFF
--- a/templates/cluster.html
+++ b/templates/cluster.html
@@ -58,9 +58,9 @@
   <div class="col">
     <div class="card text-center">
       <div class="card-body">
-        <b>{{total_score['gpu-score']}}% GPU Efficiency</b>
+        <b>{{((total_score['gpu-score'] | float) if total_usage['gpu-score'] else 0)}}% GPU Efficiency</b>
         <div class="small">
-          {{((total_usage['gpuhours'] | int) if total_usage['cputime'] else 0)}} GPU Hours
+          {{((total_usage['gpuhours'] | int) if total_usage['gpuhours'] else 0)}} GPU Hours
         </div>
       </div>
     </div>


### PR DESCRIPTION
Title says it all, if there's no gpu data we'll get a None% on the homepage without this change. This issue doesn't seem to crop up anywhere else.

Screenshot:
![image](https://user-images.githubusercontent.com/51888667/89082865-1f9f6c80-d344-11ea-856b-cfbcd52bb184.png)
